### PR TITLE
Add key repeat

### DIFF
--- a/main.py
+++ b/main.py
@@ -2,7 +2,6 @@ import ugame
 import stage
 import os
 import microcontroller
-import pew
 import sys
 import gc
 
@@ -14,7 +13,6 @@ def menu():
     game = stage.Stage(ugame.display, 12)
     cursor = stage.Text(2, 2)
     text = stage.Text(20, 16, palette=_PALETTE)
-    sprites = [cursor]
     game.layers = [cursor, text]
 
     for x in range(0, 20):
@@ -48,7 +46,6 @@ def menu():
     for i, name in enumerate(files[:13]):
         text.cursor(2, 2 + i)
         text.text(name[:17])
-        text.text("\n")
 
     x = -2
     x_anim = 0, 1, 3, 1, 0, -1, -3, -1
@@ -80,8 +77,6 @@ def menu():
 
 
 selected = menu()
-del sys.modules['pew']
-del pew
 gc.collect()
 __import__(selected)
 


### PR DESCRIPTION
This allows moving through the list quickly by keeping the up/down button pressed.

The frame rate is increased to 24 fps because 12 wasn’t sufficient to capture quick repeated button presses. As a side effect, it also allows smoother animation.

The repeat function `buttonevents` is more general than my previous one from Othello and has a customizable delay and repetition period, it implements a state machine per key.

I also have an alternative implementation of the function that stores the state in a single integer instead of a bytearray and parallelizes the loop using bitwise operations, which probably saves a bit of memory and is probably a bit faster, but the code is longer and harder to understand, so it’s probably not worth it:

```python
_repeatstates = 0
def buttonevents():
    global _repeatstates
    buttons = ugame.buttons.get_pressed()
    buttons = (buttons & 1) | ((buttons & 2) << 3) | ((buttons & 4) << 6) | ((buttons & 8) << 9) | ((buttons & 16) << 12) | ((buttons & 32) << 15) | ((buttons & 64) << 18)
    _repeatstates += buttons
    buttons = buttons | (buttons << 1) | (buttons << 2) | (buttons << 3)
    _repeatstates &= buttons
    mask = (_repeatstates >> 3) & (~_repeatstates >> 2) & (_repeatstates >> 1) & _repeatstates & 0x1111111
    _repeatstates -= mask*2
    events = (~_repeatstates >> 2) & (~_repeatstates >> 1) & _repeatstates & 0x1111111
    return ((events & 0x1000000) >> 18) | ((events & 0x100000) >> 15) | ((events & 0x10000) >> 12) | ((events & 0x1000) >> 9) | ((events & 0x100) >> 6) | ((events & 0x10) >> 3) | (events & 0x1)
```